### PR TITLE
hide() now fires aos:out:customEvent instead of aos:in:customEvent

### DIFF
--- a/src/js/helpers/handleScroll.js
+++ b/src/js/helpers/handleScroll.js
@@ -46,7 +46,7 @@ const applyClasses = (el, top) => {
     fireEvent('aos:out', node);
 
     if (el.options.id) {
-      fireEvent(`aos:in:${el.options.id}`, node);
+      fireEvent(`aos:out:${el.options.id}`, node);
     }
 
     el.animated = false;


### PR DESCRIPTION
## Related Issue

https://github.com/michalsnik/aos/issues/473
## Your solution

fixed a simple typo
## How Has This Been Tested?

Fired some custom events to test
## Screenshots (if relevant):